### PR TITLE
update the README with an example to use the split_key param

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,13 +21,13 @@ gem install fluent-plugin-split-array
 
 ## Configuration Example
 
+## Example 1
+
 ```
 <filter foo.bar.*>
   type split_array
 </filter>
 ```
-
-## Example 1
 
 ### input
 
@@ -43,6 +43,28 @@ gem install fluent-plugin-split-array
 ```
 
 ## Example 2
+
+```
+<filter foo.bar.*>
+  type split_array
+  split_key records
+</filter>
+```
+
+### input
+
+```
+{"requestId":"034f","timestamp":1578090901599,"records":[{"data":"Log entry 1"},{"data":"Log entry 2"}]}
+```
+
+### output
+
+```
+{'data' => 'Log entry 1'}
+{'data' => 'Log entry 2'}
+```
+
+## Example 3
 
 ### fluent.conf
 


### PR DESCRIPTION
Didn't find the split_key param until I read the code, hopefully the updated README will help someone not have to look at the code for the option.